### PR TITLE
feat(github): add CODEOWNERS file to enforce reviews by owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Themes and style files should be reviewed by Studios' team.
+/themes/    @ttalbot
+*.scss      @ttalbot
+*.css       @ttalbot
+*.png       @ttalbot
+*.jpeg      @ttalbot
+*.jpg       @ttalbot
+*.svg       @ttalbot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-@aifrim @bcldvd @ttalbot
+*   @aifrim @bcldvd @ttalbot
 
 # Repository management
 /scripts/   @aifrim

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,12 @@
-# Themes and style files should be reviewed by Studios' team.
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+@aifrim @bcldvd @ttalbot
+
+# Repository management
+/scripts/   @aifrim
+/tools/     @aifrim
+
+# Themes and style files
 /themes/    @ttalbot
 *.scss      @ttalbot
 *.css       @ttalbot
@@ -6,3 +14,7 @@
 *.jpeg      @ttalbot
 *.jpg       @ttalbot
 *.svg       @ttalbot
+
+# Per components owners
+/libs/angular-components/src/global-search/     @aifrim
+/libs/angular-components/src/scroll-to-top/     @aifrim


### PR DESCRIPTION
As documented in Github [here](https://help.github.com/en/articles/about-code-owners), we can request review from owners of some files / folders of a repo.
Just testing the feature at the moment before adding more owners.