### PR TITLE
fix(button): remove unused variable in button theme

### DIFF
--- a/themes/angular-theme/lib/button/_button-theme.scss
+++ b/themes/angular-theme/lib/button/_button-theme.scss
@@ -2,7 +2,6 @@
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
   $foreground: map-get($theme, foreground);
-  $finastra-gradient: linear-gradient(mat-color($primary, default), mat-color($accent, default), mat-color($uxg-crimson, 500));
 
   .mat-stroked-button {
     &.mat-primary {


### PR DESCRIPTION
Removed gradient used before creating $uxg-gradient in [palette](https://github.com/fusionfabric/finastra-design-system/blob/master/themes/angular-theme/lib/core/theming/_palette.scss#L137).