### PR TITLE
feat(popover): add component + cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,4 @@
 /libs/angular-components/global-search/     @aifrim
 /libs/angular-components/scroll-to-top/     @aifrim
 /libs/angular-components/table/             @Ping-YUAN
+/libs/angular-components/popover/           @rbordeanu

--- a/apps/angular-test-app/src/app/app-routing.module.ts
+++ b/apps/angular-test-app/src/app/app-routing.module.ts
@@ -1,35 +1,31 @@
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import {
-  MatCardModule,
-  MatChipsModule,
-  MatFormFieldModule,
-  MatInputModule,
-  MatPaginatorModule
-} from '@angular/material';
-
-import { GlobalSearchModule } from '@ffdc/uxg-angular-components/global-search';
-import { TableModule } from '@ffdc/uxg-angular-components/table';
-
-import { routes } from './routes';
+import { NgModule } from '@angular/core';
+import { MatCardModule, MatChipsModule, MatButtonModule, MatIconModule } from '@angular/material';
+import { RouterModule } from '@angular/router';
+import { ComponentsModule } from '@ffdc/uxg-angular-components';
 import { GlobalSearchDemoComponent } from './components/global-search-demo/global-search-demo.component';
-import { TableDemoComponent } from './components/table-demo/table-demo.component';
 import { HomeComponent } from './components/home/home.component';
+import { PopoverDemoComponent } from './components/popover-demo/popover-demo.component';
+import { TableDemoComponent } from './components/table-demo/table-demo.component';
+import { routes } from './routes';
+
 
 @NgModule({
   imports: [
     CommonModule,
-    MatCardModule,
-    GlobalSearchModule,
-    TableModule,
+    ComponentsModule,
     RouterModule.forRoot(routes),
+    MatCardModule,
     MatChipsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatPaginatorModule
+    MatButtonModule,
+    MatIconModule
   ],
-  declarations: [HomeComponent, GlobalSearchDemoComponent, TableDemoComponent],
+  declarations: [
+    HomeComponent,
+    GlobalSearchDemoComponent,
+    TableDemoComponent,
+    PopoverDemoComponent
+  ],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/apps/angular-test-app/src/app/app-routing.module.ts
+++ b/apps/angular-test-app/src/app/app-routing.module.ts
@@ -9,7 +9,6 @@ import { PopoverDemoComponent } from './components/popover-demo/popover-demo.com
 import { TableDemoComponent } from './components/table-demo/table-demo.component';
 import { routes } from './routes';
 
-
 @NgModule({
   imports: [
     CommonModule,
@@ -20,12 +19,7 @@ import { routes } from './routes';
     MatButtonModule,
     MatIconModule
   ],
-  declarations: [
-    HomeComponent,
-    GlobalSearchDemoComponent,
-    TableDemoComponent,
-    PopoverDemoComponent
-  ],
+  declarations: [HomeComponent, GlobalSearchDemoComponent, TableDemoComponent, PopoverDemoComponent],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/apps/angular-test-app/src/app/app.component.html
+++ b/apps/angular-test-app/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="main-container">
   <mat-sidenav-container class="uxg-nav">
-    <mat-sidenav #sidenav mode="over" fixedInViewport="true">
+    <mat-sidenav #sidenav mode="over" fixedInViewport="true" [autoFocus]="false">
       <div class="uxg-nav-header">
         <mat-card class="uxg-card-product" extra-dense routerLink="/">
           <span class="uxg-h5 uxg-card-product-name">DS</span>
@@ -14,19 +14,21 @@
         <a mat-list-item routerLink="/table" routerLinkActive="uxg-list-item-selected">
           <p>Table</p>
         </a>
+        <a mat-list-item routerLink="/popover" routerLinkActive="uxg-list-item-selected">
+          <p>Popover</p>
+        </a>
       </mat-nav-list>
     </mat-sidenav>
 
     <mat-sidenav-content>
-      <mat-toolbar class="uxg-toolbar">
+      <mat-toolbar class="uxg-toolbar uxg-toolbar-elevated">
         <button class="uxg-nav-header-button" mat-icon-button color="primary" (click)="sidenav.toggle()">
           <mat-icon>menu</mat-icon>
         </button>
         <div class="uxg-toolbar-logo-small">
-          <img src="assets/finastra-logo-small.png" />
         </div>
         <ul class="uxg-breadcrumb">
-          <li class="uxg-h6"><a routerLink="/">ANGULAR THEME</a></li>
+          <li class="uxg-h6"><a routerLink="/">ANGULAR COMPONENTS</a></li>
         </ul>
         <span class="fill-remaining-space"></span>
       </mat-toolbar>

--- a/apps/angular-test-app/src/app/app.component.html
+++ b/apps/angular-test-app/src/app/app.component.html
@@ -25,8 +25,7 @@
         <button class="uxg-nav-header-button" mat-icon-button color="primary" (click)="sidenav.toggle()">
           <mat-icon>menu</mat-icon>
         </button>
-        <div class="uxg-toolbar-logo-small">
-        </div>
+        <div class="uxg-toolbar-logo-small"></div>
         <ul class="uxg-breadcrumb">
           <li class="uxg-h6"><a routerLink="/">ANGULAR COMPONENTS</a></li>
         </ul>

--- a/apps/angular-test-app/src/app/app.component.html
+++ b/apps/angular-test-app/src/app/app.component.html
@@ -28,7 +28,7 @@
         <div class="uxg-toolbar-logo-small"></div>
         <ul class="uxg-breadcrumb">
           <li class="uxg-h6"><a routerLink="/">ANGULAR COMPONENTS</a></li>
-          <li *ngIf="title">{{title}}</li>
+          <li *ngIf="title">{{ title }}</li>
         </ul>
         <span class="fill-remaining-space"></span>
       </mat-toolbar>

--- a/apps/angular-test-app/src/app/app.component.html
+++ b/apps/angular-test-app/src/app/app.component.html
@@ -28,6 +28,7 @@
         <div class="uxg-toolbar-logo-small"></div>
         <ul class="uxg-breadcrumb">
           <li class="uxg-h6"><a routerLink="/">ANGULAR COMPONENTS</a></li>
+          <li *ngIf="title">{{title}}</li>
         </ul>
         <span class="fill-remaining-space"></span>
       </mat-toolbar>

--- a/apps/angular-test-app/src/app/app.component.scss
+++ b/apps/angular-test-app/src/app/app.component.scss
@@ -1,23 +1,39 @@
 .main-container {
-    height: 100%;
-    width: 100%;
+  height: 100%;
+  width: 100%;
 }
-
-.uxg-nav-header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-
-    .uxg-card-product {
-        cursor: pointer;
-        width: 45px;
-        margin-bottom: 10px;
+mat-sidenav-container {
+  height: 100%;
+  ::ng-deep {
+    .mat-drawer-backdrop {
+      z-index: 102;
     }
+  }
 }
+.mat-sidenav {
+  z-index: 102;
+}
+.uxg-toolbar {
+  position: fixed;
+  z-index: 101;
+}
+.uxg-nav-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 
+  .uxg-card-product {
+    cursor: pointer;
+    width: 45px;
+    margin-bottom: 10px;
+  }
+}
 .app-content {
-    height: 100%;
-    background: linear-gradient(180deg,#ebebeb 0,#fafafa 5%,#fafafa 100%);
-    padding: 2vw;
+  position: absolute;
+  top: 56px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 2rem;
 }

--- a/apps/angular-test-app/src/app/app.component.ts
+++ b/apps/angular-test-app/src/app/app.component.ts
@@ -9,13 +9,10 @@ import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 export class AppComponent {
   title: string;
 
-  constructor(
-    private router: Router,
-    private route: ActivatedRoute
-  ) {
+  constructor(private router: Router, private route: ActivatedRoute) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
-        this.title = this.route.root.firstChild.snapshot.data['title']
+        this.title = this.route.root.firstChild.snapshot.data['title'];
       }
     });
   }

--- a/apps/angular-test-app/src/app/app.component.ts
+++ b/apps/angular-test-app/src/app/app.component.ts
@@ -1,8 +1,22 @@
-import { Component, ViewChild, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'ffdc-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+export class AppComponent {
+  title: string;
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        this.title = this.route.root.firstChild.snapshot.data['title']
+      }
+    });
+  }
+}

--- a/apps/angular-test-app/src/app/app.module.ts
+++ b/apps/angular-test-app/src/app/app.module.ts
@@ -1,34 +1,26 @@
-import { NgModule } from '@angular/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
-import {
-  MatIconModule,
-  MatToolbarModule,
-  MatButtonModule,
-  MatListModule,
-  MatSidenavModule,
-  MatCardModule
-} from '@angular/material';
-
-import { AppComponent } from './app.component';
-import { AppRoutingModule } from './app-routing.module';
-
+import { NgModule } from '@angular/core';
+import { MatButtonModule, MatCardModule, MatIconModule, MatListModule, MatSidenavModule, MatToolbarModule } from '@angular/material';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GlobalSearchModule } from '@ffdc/uxg-angular-components/global-search';
 import { TableModule } from '@ffdc/uxg-angular-components/table';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { BrowserModule } from '@angular/platform-browser';
+
+
 @NgModule({
   declarations: [AppComponent],
   imports: [
-    CommonModule,
+    BrowserModule,
+    BrowserAnimationsModule,
     MatToolbarModule,
     MatIconModule,
     MatButtonModule,
-    BrowserAnimationsModule,
     MatListModule,
     MatSidenavModule,
-    AppRoutingModule,
     MatCardModule,
-    GlobalSearchModule,
-    TableModule
+    AppRoutingModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/apps/angular-test-app/src/app/app.module.ts
+++ b/apps/angular-test-app/src/app/app.module.ts
@@ -1,13 +1,19 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatButtonModule, MatCardModule, MatIconModule, MatListModule, MatSidenavModule, MatToolbarModule } from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatIconModule,
+  MatListModule,
+  MatSidenavModule,
+  MatToolbarModule
+} from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GlobalSearchModule } from '@ffdc/uxg-angular-components/global-search';
 import { TableModule } from '@ffdc/uxg-angular-components/table';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserModule } from '@angular/platform-browser';
-
 
 @NgModule({
   declarations: [AppComponent],

--- a/apps/angular-test-app/src/app/components/home/home.component.html
+++ b/apps/angular-test-app/src/app/components/home/home.component.html
@@ -46,6 +46,17 @@ imports: [
           </mat-card-subtitle>
         </mat-card-title-group>
       </mat-card>
+      <mat-card routerLink="/popover">
+        <img mat-card-image src="assets/bar-chart.png" alt="Abstract illustration of an avatar" />
+        <mat-card-title-group>
+          <mat-card-title class="uxg-h4">Popover</mat-card-title>
+          <mat-card-subtitle class="uxg-overline">
+            <mat-chip-list>
+              <mat-chip disabled dense>Popover</mat-chip>
+            </mat-chip-list>
+          </mat-card-subtitle>
+        </mat-card-title-group>
+      </mat-card>
     </div>
   </div>
 </div>

--- a/apps/angular-test-app/src/app/components/home/home.component.html
+++ b/apps/angular-test-app/src/app/components/home/home.component.html
@@ -29,7 +29,9 @@ imports: [
         <mat-card-title-group>
           <mat-card-title class="uxg-h4">Global Search</mat-card-title>
           <mat-card-subtitle class="uxg-overline">
-            <mat-chip disabled dense>SEARCH</mat-chip>
+          <mat-chip-list>
+            <mat-chip disabled dense>Search</mat-chip>
+          </mat-chip-list>
           </mat-card-subtitle>
         </mat-card-title-group>
       </mat-card>
@@ -38,7 +40,9 @@ imports: [
         <mat-card-title-group>
           <mat-card-title class="uxg-h4">Table</mat-card-title>
           <mat-card-subtitle class="uxg-overline">
+          <mat-chip-list>
             <mat-chip disabled dense>Table</mat-chip>
+          </mat-chip-list>
           </mat-card-subtitle>
         </mat-card-title-group>
       </mat-card>

--- a/apps/angular-test-app/src/app/components/home/home.component.html
+++ b/apps/angular-test-app/src/app/components/home/home.component.html
@@ -29,9 +29,9 @@ imports: [
         <mat-card-title-group>
           <mat-card-title class="uxg-h4">Global Search</mat-card-title>
           <mat-card-subtitle class="uxg-overline">
-          <mat-chip-list>
-            <mat-chip disabled dense>Search</mat-chip>
-          </mat-chip-list>
+            <mat-chip-list>
+              <mat-chip disabled dense>Search</mat-chip>
+            </mat-chip-list>
           </mat-card-subtitle>
         </mat-card-title-group>
       </mat-card>
@@ -40,9 +40,9 @@ imports: [
         <mat-card-title-group>
           <mat-card-title class="uxg-h4">Table</mat-card-title>
           <mat-card-subtitle class="uxg-overline">
-          <mat-chip-list>
-            <mat-chip disabled dense>Table</mat-chip>
-          </mat-chip-list>
+            <mat-chip-list>
+              <mat-chip disabled dense>Table</mat-chip>
+            </mat-chip-list>
           </mat-card-subtitle>
         </mat-card-title-group>
       </mat-card>

--- a/apps/angular-test-app/src/app/components/home/home.component.scss
+++ b/apps/angular-test-app/src/app/components/home/home.component.scss
@@ -48,7 +48,7 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: flex-start;
-    
+
         .mat-card {
             width: 210px;
             margin: 20px 10px;

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.html
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.html
@@ -1,0 +1,17 @@
+<div class="wrapper">
+  <uxg-popover #popover [popoverContent]="popoverContent" popoverClass="popover">
+    <button mat-stroked-button color="accent">Click me to see a popover</button>
+  </uxg-popover>
+</div>
+
+<ng-template #popoverContent>
+  <div class="uxg-h5">Simple popover</div>
+  <div class="uxg-body-2">
+    This popover is pretty simple. It uses Material menu to work like a popover. The benefit of this approach is it's
+    super lightweight. And it is very flexible as well.
+  </div>
+  <div class="actions">
+    <button mat-button color="accent" (click)="popover.close()">Close</button>
+    <button mat-flat-button color="accent" (click)="popover.close()">Sounds good</button>
+  </div>
+</ng-template>

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.scss
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.scss
@@ -1,0 +1,19 @@
+.wrapper {
+  display: flex;
+  justify-content: center;
+  //align-items: center;
+  height: 100%;
+}
+
+.popover {
+  max-width: 400px !important;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 16px;
+  button {
+    margin-left: 10px;
+  }
+}

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PopoverDemoComponent } from './popover-demo.component';
+
+describe('PopoverDemoComponent', () => {
+  let component: PopoverDemoComponent;
+  let fixture: ComponentFixture<PopoverDemoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PopoverDemoComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PopoverDemoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverDemoComponent } from './popover-demo.component';
+import { PopoverModule } from 'libs/angular-components/popover/src/popover.module';
 
 describe('PopoverDemoComponent', () => {
   let component: PopoverDemoComponent;
@@ -8,6 +9,7 @@ describe('PopoverDemoComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [PopoverModule],
       declarations: [PopoverDemoComponent]
     }).compileComponents();
   }));

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverDemoComponent } from './popover-demo.component';
-import { PopoverModule } from 'libs/angular-components/popover/src/popover.module';
+import { PopoverModule } from '@ffdc/uxg-angular-components/popover';
 
 describe('PopoverDemoComponent', () => {
   let component: PopoverDemoComponent;

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.spec.ts
@@ -8,9 +8,8 @@ describe('PopoverDemoComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PopoverDemoComponent ]
-    })
-    .compileComponents();
+      declarations: [PopoverDemoComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'ffdc-popover-demo',
+  templateUrl: './popover-demo.component.html',
+  styleUrls: ['./popover-demo.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class PopoverDemoComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.ts
+++ b/apps/angular-test-app/src/app/components/popover-demo/popover-demo.component.ts
@@ -7,10 +7,7 @@ import { Component, OnInit, ViewEncapsulation } from '@angular/core';
   encapsulation: ViewEncapsulation.None
 })
 export class PopoverDemoComponent implements OnInit {
+  constructor() {}
 
-  constructor() { }
-
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/apps/angular-test-app/src/app/routes.ts
+++ b/apps/angular-test-app/src/app/routes.ts
@@ -1,9 +1,8 @@
 import { Routes } from '@angular/router';
-import { PopoverComponent } from 'libs/angular-components/popover/src/popover.component';
 import { GlobalSearchDemoComponent } from './components/global-search-demo/global-search-demo.component';
 import { HomeComponent } from './components/home/home.component';
-import { TableDemoComponent } from './components/table-demo/table-demo.component';
 import { PopoverDemoComponent } from './components/popover-demo/popover-demo.component';
+import { TableDemoComponent } from './components/table-demo/table-demo.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },

--- a/apps/angular-test-app/src/app/routes.ts
+++ b/apps/angular-test-app/src/app/routes.ts
@@ -6,7 +6,7 @@ import { TableDemoComponent } from './components/table-demo/table-demo.component
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
-  { path: 'global-search', component: GlobalSearchDemoComponent },
-  { path: 'table', component: TableDemoComponent },
-  { path: 'popover', component: PopoverDemoComponent }
+  { path: 'global-search', component: GlobalSearchDemoComponent, data: { title: 'Global Search Demo' } },
+  { path: 'table', component: TableDemoComponent, data: { title: 'Table Demo' } },
+  { path: 'popover', component: PopoverDemoComponent, data: { title: 'Popover Demo' } }
 ];

--- a/apps/angular-test-app/src/app/routes.ts
+++ b/apps/angular-test-app/src/app/routes.ts
@@ -1,10 +1,13 @@
 import { Routes } from '@angular/router';
-import { HomeComponent } from './components/home/home.component';
+import { PopoverComponent } from 'libs/angular-components/popover/src/popover.component';
 import { GlobalSearchDemoComponent } from './components/global-search-demo/global-search-demo.component';
+import { HomeComponent } from './components/home/home.component';
 import { TableDemoComponent } from './components/table-demo/table-demo.component';
+import { PopoverDemoComponent } from './components/popover-demo/popover-demo.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'global-search', component: GlobalSearchDemoComponent },
-  { path: 'table', component: TableDemoComponent }
+  { path: 'table', component: TableDemoComponent },
+  { path: 'popover', component: PopoverDemoComponent }
 ];

--- a/apps/angular-test-app/src/styles.scss
+++ b/apps/angular-test-app/src/styles.scss
@@ -1,7 +1,9 @@
 @import '../../../themes/angular-theme/all-theme';
 @import '../../../libs/angular-components/global-search/src/global-search-theme.component';
+@import '../../../libs/angular-components/popover/src/popover.theme';
 
 @include uxg-global-search-theme($uxg-light-theme);
+@include uxg-popover-theme($uxg-light-theme);
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/libs/angular-components/components.module.ts
+++ b/libs/angular-components/components.module.ts
@@ -5,10 +5,10 @@ import { GlobalSearchModule } from './global-search/src/global-search.module';
 import { GlobalSearchService } from './global-search/src/services/global-search.service';
 import { ScrollToTopModule } from './scroll-to-top/src/scroll-to-top.module';
 import { TableModule } from './table/src/table.module';
+import { PopoverModule } from './popover/src/popover.module';
 
 @NgModule({
   imports: [CommonModule],
-  exports: [GlobalSearchModule, ScrollToTopModule, TableModule],
-  providers: [GlobalSearchService]
+  exports: [GlobalSearchModule, ScrollToTopModule, TableModule, PopoverModule]
 })
 export class ComponentsModule {}

--- a/libs/angular-components/popover/ng-package.json
+++ b/libs/angular-components/popover/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/angular-components/popover",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/angular-components/popover/package.json
+++ b/libs/angular-components/popover/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@ffdc/uxg-angular-components/popover",
+  "version": "0.13.2",
+  "author": "Razvan Bordeanu <razvan.bordeanu@finastra.com>"
+}

--- a/libs/angular-components/popover/src/_popover.theme.scss
+++ b/libs/angular-components/popover/src/_popover.theme.scss
@@ -1,0 +1,19 @@
+@mixin uxg-popover-theme($theme) {
+  .uxg-popover {
+    .mat-menu-item {
+      height: auto;
+      white-space: normal;
+      line-height: inherit;
+      display: flex;
+      flex-direction: column;
+      padding: $uxg-spacing-3;
+      &.cdk-program-focused:not([disabled]),
+      &:hover:not([disabled]) {
+        background: inherit;
+      }
+    }
+    .mat-menu-content {
+      padding: 0 !important;
+    }
+  }
+}

--- a/libs/angular-components/popover/src/index.ts
+++ b/libs/angular-components/popover/src/index.ts
@@ -1,0 +1,1 @@
+export * from './popover.module';

--- a/libs/angular-components/popover/src/popover.component.html
+++ b/libs/angular-components/popover/src/popover.component.html
@@ -1,4 +1,4 @@
-<mat-menu #popover="matMenu" [xPosition]="xPosition" [yPosition]="yPosition" class="uxg-popover {{popoverClass}}">
+<mat-menu #popover="matMenu" [xPosition]="xPosition" [yPosition]="yPosition" class="uxg-popover {{ popoverClass }}">
   <ng-template matMenuContent>
     <span mat-menu-item [disableRipple]="true" (click)="$event.stopPropagation()">
       <ng-container *ngTemplateOutlet="popoverContent"></ng-container>

--- a/libs/angular-components/popover/src/popover.component.html
+++ b/libs/angular-components/popover/src/popover.component.html
@@ -1,0 +1,10 @@
+<mat-menu #popover="matMenu" [xPosition]="xPosition" [yPosition]="yPosition" class="uxg-popover {{popoverClass}}">
+  <ng-template matMenuContent>
+    <span mat-menu-item [disableRipple]="true" (click)="$event.stopPropagation()">
+      <ng-container *ngTemplateOutlet="popoverContent"></ng-container>
+    </span>
+  </ng-template>
+</mat-menu>
+<div [matMenuTriggerFor]="popover">
+  <ng-content></ng-content>
+</div>

--- a/libs/angular-components/popover/src/popover.component.spec.ts
+++ b/libs/angular-components/popover/src/popover.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PopoverComponent } from './popover.component';
+
+describe('PopoverModule', () => {
+  let component: PopoverComponent;
+  let fixture: ComponentFixture<PopoverComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PopoverComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PopoverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/angular-components/popover/src/popover.component.spec.ts
+++ b/libs/angular-components/popover/src/popover.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverComponent } from './popover.component';
+import { MatMenuModule } from '@angular/material';
+import { CommonModule } from '@angular/common';
 
 describe('PopoverModule', () => {
   let component: PopoverComponent;
@@ -8,6 +10,7 @@ describe('PopoverModule', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [CommonModule, MatMenuModule],
       declarations: [PopoverComponent]
     }).compileComponents();
   }));

--- a/libs/angular-components/popover/src/popover.component.spec.ts
+++ b/libs/angular-components/popover/src/popover.component.spec.ts
@@ -8,9 +8,8 @@ describe('PopoverModule', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PopoverComponent ]
-    })
-    .compileComponents();
+      declarations: [PopoverComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/libs/angular-components/popover/src/popover.component.ts
+++ b/libs/angular-components/popover/src/popover.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { MatMenuTrigger, MenuPositionX, MenuPositionY } from '@angular/material';
+
+@Component({
+  selector: 'uxg-popover',
+  templateUrl: './popover.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PopoverComponent {
+  @Input() xPosition: MenuPositionX = 'after';
+  @Input() yPosition: MenuPositionY = 'below';
+  @Input() popoverContent: TemplateRef<any>;
+  @Input() popoverClass: string = '';
+
+  @ViewChild(MatMenuTrigger, { static: true }) private matMenuTrigger: MatMenuTrigger;
+
+  open() {
+    this.matMenuTrigger.openMenu();
+  }
+
+  close() {
+    this.matMenuTrigger.closeMenu();
+  }
+
+}

--- a/libs/angular-components/popover/src/popover.component.ts
+++ b/libs/angular-components/popover/src/popover.component.ts
@@ -10,7 +10,7 @@ export class PopoverComponent {
   @Input() xPosition: MenuPositionX = 'after';
   @Input() yPosition: MenuPositionY = 'below';
   @Input() popoverContent: TemplateRef<any>;
-  @Input() popoverClass: string = '';
+  @Input() popoverClass: string;
 
   @ViewChild(MatMenuTrigger, { static: true }) private matMenuTrigger: MatMenuTrigger;
 

--- a/libs/angular-components/popover/src/popover.component.ts
+++ b/libs/angular-components/popover/src/popover.component.ts
@@ -21,5 +21,4 @@ export class PopoverComponent {
   close() {
     this.matMenuTrigger.closeMenu();
   }
-
 }

--- a/libs/angular-components/popover/src/popover.module.spec.ts
+++ b/libs/angular-components/popover/src/popover.module.spec.ts
@@ -1,0 +1,14 @@
+import { async, TestBed } from '@angular/core/testing';
+import { PopoverModule } from './popover.module';
+
+describe('PopoverModule', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [PopoverModule]
+    }).compileComponents();
+  }));
+
+  it('should create', () => {
+    expect(PopoverModule).toBeDefined();
+  });
+});

--- a/libs/angular-components/popover/src/popover.module.ts
+++ b/libs/angular-components/popover/src/popover.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+
+import { PopoverComponent } from './popover.component';
+import { CommonModule } from '@angular/common';
+import { MatMenuModule } from '@angular/material';
+
+@NgModule({
+  imports: [CommonModule, MatMenuModule],
+  declarations: [PopoverComponent],
+  exports: [PopoverComponent]
+})
+export class PopoverModule {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,39 +10,19 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2017", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@ffdc/devkit": [
-        "dist/devkit/"
-      ],
-      "@ffdc/uxg-angular-components": [
-        "libs/angular-components/index.ts"
-      ],
-      "@ffdc/uxg-angular-components/global-search": [
-        "libs/angular-components/global-search/src/index.ts"
-      ],
-      "@ffdc/uxg-angular-components/scroll-to-top": [
-        "libs/angular-components/scroll-to-top/src/index.ts"
-      ],
-      "@ffdc/uxg-angular-components/table": [
-        "libs/angular-components/table/src/index.ts"
-      ],
-      "@ffdc/uxg-angular-components/popover": [
-        "libs/angular-components/popover/src/index.ts"
-      ]
+      "@ffdc/devkit": ["dist/devkit/"],
+      "@ffdc/uxg-angular-components": ["libs/angular-components/index.ts"],
+      "@ffdc/uxg-angular-components/global-search": ["libs/angular-components/global-search/src/index.ts"],
+      "@ffdc/uxg-angular-components/scroll-to-top": ["libs/angular-components/scroll-to-top/src/index.ts"],
+      "@ffdc/uxg-angular-components/table": ["libs/angular-components/table/src/index.ts"],
+      "@ffdc/uxg-angular-components/popover": ["libs/angular-components/popover/src/index.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,18 +10,39 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "typeRoots": ["node_modules/@types"],
-    "lib": ["es2017", "dom"],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@ffdc/devkit": ["dist/devkit/"],
-      "@ffdc/uxg-angular-components": ["libs/angular-components/index.ts"],
-      "@ffdc/uxg-angular-components/global-search": ["libs/angular-components/global-search/src/index.ts"],
-      "@ffdc/uxg-angular-components/scroll-to-top": ["libs/angular-components/scroll-to-top/src/index.ts"],
-      "@ffdc/uxg-angular-components/table": ["libs/angular-components/table/src/index.ts"]
+      "@ffdc/devkit": [
+        "dist/devkit/"
+      ],
+      "@ffdc/uxg-angular-components": [
+        "libs/angular-components/index.ts"
+      ],
+      "@ffdc/uxg-angular-components/global-search": [
+        "libs/angular-components/global-search/src/index.ts"
+      ],
+      "@ffdc/uxg-angular-components/scroll-to-top": [
+        "libs/angular-components/scroll-to-top/src/index.ts"
+      ],
+      "@ffdc/uxg-angular-components/table": [
+        "libs/angular-components/table/src/index.ts"
+      ],
+      "@ffdc/uxg-angular-components/popover": [
+        "libs/angular-components/popover/src/index.ts"
+      ]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }


### PR DESCRIPTION
<img width="482" alt="Screenshot 2019-09-10 at 17 27 27" src="https://user-images.githubusercontent.com/14875191/64622633-50a34580-d3f0-11e9-9cd7-36d2a546c271.png">

Simple popover based on mat-menu (Material doesn't offer such widget by default)

You can configure x- and y- positions and apply a css class for the panel (to change max-width for example), and of course provide the content as a template.