### PR TITLE
fix(card): remove margin-left on card+card. 

### DIFF
--- a/themes/angular-theme/lib/card/_card-base.scss
+++ b/themes/angular-theme/lib/card/_card-base.scss
@@ -30,10 +30,6 @@ $mat-card-padding: $uxg-spacing-3;
 .mat-card {
   padding: $mat-card-padding;
 
-  & + .mat-card {
-    margin-left: $uxg-spacing-2;
-  }
-
   .uxg-card-image-overlay {
     position: relative;
     margin: 0 (-$mat-card-padding) $uxg-spacing-3 (-$mat-card-padding);


### PR DESCRIPTION
It works only for a horizontal list of cards, not on grids.
Here is the shift generated by the margin-left on grids:
![Screenshot 2019-10-01 at 10 55 32](https://user-images.githubusercontent.com/371041/65948205-13a00100-e43a-11e9-9148-ca6d3e6a02b3.png)
