### PR TITLE
fix(typography): add more and better fallback fonts for Futura

### DIFF
--- a/themes/angular-theme/lib/core/typography/_typography.scss
+++ b/themes/angular-theme/lib/core/typography/_typography.scss
@@ -1,7 +1,7 @@
 @import '~@angular/material/theming';
 
 $primary-font: 'Roboto, roboto, "Helvetica Neue", sans-serif';
-$secondary-font: '"futura-pt", "Futura EF", Futura, "Arial Black", "Century Gothic"';
+$secondary-font: '"Futura EF", "futura-pt", "Futura", "Hind", "Verdana", "Arial Black", sans-serif';
 
 // font-weight :
 // light = 300


### PR DESCRIPTION
Since Futura is licensed font, we need to provide alternatives for people not buying it.
1. We first try to load Futura from different foundries (if loaded or installed on client)
   `Futura EF` - `Futura PT` - `Futura`

   ![Screenshot 2019-10-11 at 10 22 06](https://user-images.githubusercontent.com/371041/66636269-23c19880-ec11-11e9-95c7-0d2a8500ac12.png)

2. Then we try an open font from Google
   `Hind`

   ![Screenshot 2019-10-11 at 10 22 26](https://user-images.githubusercontent.com/371041/66636290-34720e80-ec11-11e9-8a09-223d1234fc98.png)

3. Then we load closest looking system fonts
   `Verdana` - `Arial Black`

   ![Screenshot 2019-10-11 at 10 22 42](https://user-images.githubusercontent.com/371041/66636305-3b991c80-ec11-11e9-9687-72904aa19af4.png)

4. Finally we use generic font family name
   `sans-serif`

   ![Screenshot 2019-10-11 at 10 22 58](https://user-images.githubusercontent.com/371041/66636319-42c02a80-ec11-11e9-9947-4d01c0f93873.png)
