### PR TITLE
fix(typography): apply body-1 on paragraphs by default

### DIFF
--- a/themes/angular-theme/lib/core/typography/_typography.scss
+++ b/themes/angular-theme/lib/core/typography/_typography.scss
@@ -123,7 +123,8 @@ $secondary-font: '"futura-pt", "Futura EF", Futura, "Arial Black", "Century Goth
     @include mat-typography-level-to-styles($config, subtitle-2);
   }
 
-  .uxg-body-1 {
+  .uxg-body-1,
+  #{$selector} p {
     @include mat-typography-level-to-styles($config, body-1);
   }
 


### PR DESCRIPTION
Apply `uxg-body-1` on `<p>` by default when using class .uxg-typography on body.