### PR TITLE
feat(bundle): properly bundle all css

### DIFF
--- a/apps/angular-test-app/src/app/app-routing.module.ts
+++ b/apps/angular-test-app/src/app/app-routing.module.ts
@@ -1,17 +1,28 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MatCardModule, MatChipsModule, MatButtonModule, MatIconModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
-import { ComponentsModule } from '@ffdc/uxg-angular-components';
+import { GlobalSearchModule } from '@ffdc/uxg-angular-components/global-search';
+import { ScrollToTopModule } from '@ffdc/uxg-angular-components/scroll-to-top';
+import { UxgTableModule } from '@ffdc/uxg-angular-components/table';
+import { PopoverModule } from '@ffdc/uxg-angular-components/popover';
+
+import { routes } from './routes';
+import { MaterialModule } from './material.module';
 import { GlobalSearchDemoComponent } from './components/global-search-demo/global-search-demo.component';
 import { HomeComponent } from './components/home/home.component';
 import { PopoverDemoComponent } from './components/popover-demo/popover-demo.component';
 import { TableDemoComponent } from './components/table-demo/table-demo.component';
-import { routes } from './routes';
-import { MaterialModule } from './material.module';
 
 @NgModule({
-  imports: [CommonModule, MaterialModule, ComponentsModule, RouterModule.forRoot(routes)],
+  imports: [
+    CommonModule,
+    MaterialModule,
+    RouterModule.forRoot(routes),
+    GlobalSearchModule,
+    ScrollToTopModule,
+    PopoverModule,
+    UxgTableModule
+  ],
   declarations: [HomeComponent, GlobalSearchDemoComponent, TableDemoComponent, PopoverDemoComponent],
   exports: [RouterModule]
 })

--- a/apps/angular-test-app/src/styles.scss
+++ b/apps/angular-test-app/src/styles.scss
@@ -1,9 +1,4 @@
 @import '../../../themes/angular-theme/all-theme';
-@import '../../../libs/angular-components/global-search/src/global-search.theme';
-@import '../../../libs/angular-components/popover/src/popover.theme';
-
-@include uxg-global-search-theme($uxg-light-theme);
-@include uxg-popover-theme($uxg-light-theme);
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/libs/angular-components/global-search/src/global-search.component.scss
+++ b/libs/angular-components/global-search/src/global-search.component.scss
@@ -1,3 +1,8 @@
+@import '../../../../themes/angular-theme/uxg-app-theme';
+
+@import './global-search.theme';
+@include uxg-global-search-theme($uxg-light-theme);
+
 $close-button-size: 48px;
 
 .uxg-global-search-overlay-pane {

--- a/libs/angular-components/popover/src/popover.component.scss
+++ b/libs/angular-components/popover/src/popover.component.scss
@@ -1,0 +1,3 @@
+@import '../../../../themes/angular-theme/uxg-app-theme';
+@import './popover.theme';
+@include uxg-popover-theme($uxg-light-theme);

--- a/libs/angular-components/popover/src/popover.component.ts
+++ b/libs/angular-components/popover/src/popover.component.ts
@@ -4,6 +4,7 @@ import { MatMenuTrigger, MenuPositionX, MenuPositionY } from '@angular/material'
 @Component({
   selector: 'uxg-popover',
   templateUrl: './popover.component.html',
+  styleUrls: ['./popover.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PopoverComponent {

--- a/libs/angular-components/table/src/table.component.scss
+++ b/libs/angular-components/table/src/table.component.scss
@@ -1,5 +1,4 @@
-
-$uxg-table-max-height: 528px; // display maximum 10 rows 
+$uxg-table-max-height: 528px; // display maximum 10 rows
 
 uxg-table {
     flex: 1;

--- a/tools/schematics/angular-component/files/src/__filename__.component.scss.template
+++ b/tools/schematics/angular-component/files/src/__filename__.component.scss.template
@@ -1,0 +1,3 @@
+@import '../../../../themes/angular-theme/uxg-app-theme';
+@import './<%= filename %>.theme';
+@include uxg-<%= filename %>-theme($uxg-light-theme);

--- a/tools/schematics/angular-component/files/src/__scssFilename__.theme.scss.template
+++ b/tools/schematics/angular-component/files/src/__scssFilename__.theme.scss.template
@@ -1,0 +1,2 @@
+@mixin uxg-<%= filename %>-colors($theme) {
+}

--- a/tools/schematics/angular-component/index.ts
+++ b/tools/schematics/angular-component/index.ts
@@ -41,6 +41,7 @@ export default function(schema: Schema): Rule {
         ...strings,
         className: classNamePrefix,
         filename,
+        scssFilename: `_${filename}`,
         version: pkg.version,
         author: `${user.name} <${user.email}>`
       }),


### PR DESCRIPTION
In order for the components to contain their styles we will need to do this in the component main scss
1. import the `uxg-app-theme`
2. import the `component-theme`
3. use the component mixin

Example from the global-search component:
```scss
@import '../../../../themes/angular-theme/uxg-app-theme';

@import './global-search.theme';
@include uxg-global-search-theme($uxg-light-theme);
```

I have updated the component schematic with these new changes.

**NOTE 1:** Components that do not require theming, need not use this.
**NOTE 2:** Relative pathing to the `uxg-app-theme` did not work

**NOTE 3:** In order to allow themes we will need to refactor all the components and the theme. 
We will neeed to import `_component.theme.scss` into the `uxg-angular-theme` and build it there two times for both themes. This is a provisional solution until we make a decision on how to supply theming within the FDS.