### PR TITLE
fix(typography): remove default uxg-body-1 on paragraph

### DIFF
--- a/themes/angular-theme/lib/core/typography/_typography.scss
+++ b/themes/angular-theme/lib/core/typography/_typography.scss
@@ -123,8 +123,7 @@ $secondary-font: '"Futura EF", "futura-pt", "Futura", "Hind", "Verdana", "Arial 
     @include mat-typography-level-to-styles($config, subtitle-2);
   }
 
-  .uxg-body-1,
-  #{$selector} p {
+  .uxg-body-1 {
     @include mat-typography-level-to-styles($config, body-1);
   }
 


### PR DESCRIPTION
Styling on p is much stronger than styling on class.
As a result it overrides every other styles (uxg-subtitle / uxg-display / ...) including the ones in other ui-elements.
where it is acceptable to have default headlines styles, it is not on paragraph since it can be used for many other usages (display / subtitle / body / ...)
The best strategy is to have lighter styling level possible on typography, which is class level only.