### PR TITLE
feat(badge-styles): add large side badges

### DIFF
--- a/themes/angular-theme/lib/badge/_badge-base.scss
+++ b/themes/angular-theme/lib/badge/_badge-base.scss
@@ -1,29 +1,35 @@
+@import '../core/style/spacing';
+
+$side-badge-border-width: 1px;
+$side-badge-radius-standard: 12px;
+$side-badge-radius-large: 14px;
+$side-badge-min-width-large: 14px;
+
 @mixin uxg-side-badge-base() {
   position: relative;
   border-style: solid;
-  border-width: 1px;
+  border-width: $side-badge-border-width;
   height: unset;
   width: unset;
   top: unset;
   right: unset;
   vertical-align: middle;
+  margin: 0 $uxg-spacing-2;
 }
 
 .uxg-side-badge {
   &.mat-badge-medium.mat-badge-after span.mat-badge-content {
     @include uxg-side-badge-base();
 
-    border-radius: 12px;
-    padding: 0 8px;
-    margin: 0 8px;
+    border-radius: $side-badge-radius-standard;
+    padding: 0 $uxg-spacing-2;
   }
 
   &.mat-badge-large.mat-badge-after span.mat-badge-content {
     @include uxg-side-badge-base();
 
-    border-radius: 14px;
+    border-radius: $side-badge-radius-large;
     padding: 2px 12px;
-    margin: 0 10px;
-    min-width: 14px;
+    min-width: $side-badge-min-width-large;
   }
 }

--- a/themes/angular-theme/lib/badge/_badge-base.scss
+++ b/themes/angular-theme/lib/badge/_badge-base.scss
@@ -12,12 +12,15 @@
 .uxg-side-badge {
   &.mat-badge-medium.mat-badge-after span.mat-badge-content {
     @include uxg-side-badge-base();
+
     border-radius: 12px;
     padding: 0 8px;
     margin: 0 8px;
   }
+
   &.mat-badge-large.mat-badge-after span.mat-badge-content {
     @include uxg-side-badge-base();
+
     border-radius: 14px;
     padding: 2px 12px;
     margin: 0 10px;

--- a/themes/angular-theme/lib/badge/_badge-base.scss
+++ b/themes/angular-theme/lib/badge/_badge-base.scss
@@ -1,13 +1,26 @@
-.uxg-side-badge.mat-badge-medium.mat-badge-after span.mat-badge-content {
+@mixin uxg-side-badge-base() {
   position: relative;
   border-style: solid;
   border-width: 1px;
-  border-radius: 12px;
   height: unset;
   width: unset;
   top: unset;
   right: unset;
-  padding: 0 8px;
   vertical-align: middle;
-  margin: 0 8px;
+}
+
+.uxg-side-badge {
+  &.mat-badge-medium.mat-badge-after span.mat-badge-content {
+    @include uxg-side-badge-base();
+    border-radius: 12px;
+    padding: 0 8px;
+    margin: 0 8px;
+  }
+  &.mat-badge-large.mat-badge-after span.mat-badge-content {
+    @include uxg-side-badge-base();
+    border-radius: 14px;
+    padding: 2px 12px;
+    margin: 0 10px;
+    min-width: 14px;
+  }
 }

--- a/themes/angular-theme/lib/badge/_badge-theme.scss
+++ b/themes/angular-theme/lib/badge/_badge-theme.scss
@@ -9,12 +9,23 @@
 }
 
 @mixin uxg-badge-typography($config) {
-  .uxg-side-badge.mat-badge-medium.mat-badge-after {
-    .mat-badge-content {
-      line-height: 16px;
-      font: {
-        size: 10px;
-        weight: 300;
+  .uxg-side-badge {
+    &.mat-badge-medium.mat-badge-after {
+      .mat-badge-content {
+        line-height: 16px;
+        font: {
+          size: 10px;
+          weight: 300;
+        }
+      }
+    }
+    &.mat-badge-large.mat-badge-after {
+      .mat-badge-content {
+        line-height: 22px;
+        font: {
+          size: 14px;
+          weight: 400;
+        }
       }
     }
   }

--- a/themes/angular-theme/lib/badge/_badge-theme.scss
+++ b/themes/angular-theme/lib/badge/_badge-theme.scss
@@ -19,6 +19,7 @@
         }
       }
     }
+
     &.mat-badge-large.mat-badge-after {
       .mat-badge-content {
         line-height: 22px;

--- a/themes/angular-theme/lib/badge/_badge-theme.scss
+++ b/themes/angular-theme/lib/badge/_badge-theme.scss
@@ -12,21 +12,15 @@
   .uxg-side-badge {
     &.mat-badge-medium.mat-badge-after {
       .mat-badge-content {
-        line-height: 16px;
-        font: {
-          size: 10px;
-          weight: 300;
-        }
+        @include mat-typography-level-to-styles($config, overline);
+        font-weight: mat-font-weight($config, display-6);
       }
     }
 
     &.mat-badge-large.mat-badge-after {
       .mat-badge-content {
-        line-height: 22px;
-        font: {
-          size: 14px;
-          weight: 400;
-        }
+        @include mat-typography-level-to-styles($config, subtitle-2);
+        font-weight: mat-font-weight($config, caption);
       }
     }
   }

--- a/themes/angular-theme/lib/badge/_badge-theme.scss
+++ b/themes/angular-theme/lib/badge/_badge-theme.scss
@@ -13,6 +13,7 @@
     &.mat-badge-medium.mat-badge-after {
       .mat-badge-content {
         @include mat-typography-level-to-styles($config, overline);
+
         font-weight: mat-font-weight($config, display-6);
       }
     }
@@ -20,6 +21,7 @@
     &.mat-badge-large.mat-badge-after {
       .mat-badge-content {
         @include mat-typography-level-to-styles($config, subtitle-2);
+
         font-weight: mat-font-weight($config, caption);
       }
     }


### PR DESCRIPTION
Closes #43 

Large side badges are now properly rendered in similar style to medium ones.

<img width="625" alt="Screenshot 2019-10-23 at 02 38 03" src="https://user-images.githubusercontent.com/14875191/67344140-eda0e480-f53f-11e9-8fc8-edeb741e677f.png">
