### PR TITLE
fet(theme): dense chips style fixed + large chips style added

### DIFF
--- a/themes/angular-theme/lib/chips/_chips-base.scss
+++ b/themes/angular-theme/lib/chips/_chips-base.scss
@@ -1,8 +1,17 @@
-$chip-min-height-dense: 25px;
-$chip-font-size-dense: 12px;
+$chip-min-height-dense: 18px;
+$chip-min-height-standart: 24px;
+$chip-min-height-large: 32px;
+
+.mat-chip.mat-standard-chip {
+  min-height: $chip-min-height-standart;
+}
+
+.mat-chip[large],
+*[large] .mat-chip {
+  min-height: $chip-min-height-large;
+}
 
 .mat-chip[dense],
 *[dense] .mat-chip {
   min-height: $chip-min-height-dense;
-  font-size: $chip-font-size-dense;
 }

--- a/themes/angular-theme/lib/chips/_chips-theme.scss
+++ b/themes/angular-theme/lib/chips/_chips-theme.scss
@@ -72,10 +72,18 @@
 
 @mixin uxg-chips-typography($config) {
   .mat-chip {
+    @include mat-typography-level-to-styles($config, body-3);
+  }
+
+  .mat-chip[large] {
     @include mat-typography-level-to-styles($config, body-2);
+
+    font-weight: mat-font-weight($config, body-3);
   }
 
   .mat-chip[dense] {
-    @include mat-typography-level-to-styles($config, caption);
+    @include mat-typography-level-to-styles($config, overline);
+
+    font-weight: mat-font-weight($config, body-3);
   }
 }

--- a/themes/angular-theme/lib/icon/_icon-base.scss
+++ b/themes/angular-theme/lib/icon/_icon-base.scss
@@ -1,9 +1,9 @@
 @import '../core/style/spacing';
 
 $icon-size-extra-large: $uxg-spacing-5;
-$icon-size-large: 36px;
+$icon-size-large: 18px;
 $icon-size-base: $uxg-spacing-4;
-$icon-size-dense: 18px;
+$icon-size-dense: 14px;
 
 @mixin icon-size($icon-size) {
   width: $icon-size !important;
@@ -12,19 +12,23 @@ $icon-size-dense: 18px;
   line-height: $icon-size !important;
 }
 
-.mat-icon[dense],
+.mat-icon.mat-icon[dense],
 *[dense] .mat-icon {
   @include icon-size($icon-size-dense);
 }
 
-.mat-icon[large],
+.mat-icon.mat-icon[large],
 *[large] .mat-icon {
   @include icon-size($icon-size-large);
 }
 
-.mat-icon[extra-large],
+.mat-icon.mat-icon[extra-large],
 *[extra-large] .mat-icon {
   @include icon-size($icon-size-extra-large);
+}
+
+.mat-icon {
+  @include icon-size($icon-size-dense);
 }
 
 button {


### PR DESCRIPTION
@rbordeanu this is about what you commented on pull request #52 
I finished setting the styles for the dense chips, including the closing icon and I added the large style as well. 
There is a linting problem I am not sure how to solve. It is in the file "themes/angular-theme/lib/icon/_icon-base.scss" and the error is: "30:1  Expected selector .mat-icon to come before selector *[dense] .mat-icon"
Let me know if you have an idea on how to solve this. I believe that demands a refactoring of the scss variables but perhaps there is an easier way. Thanks!