### PR TITLE
bugfix(filter-tree): fixed tree-divider rendering condition

### DIFF
--- a/libs/angular-components/filter/filter-tree/src/filter-tree.component.html
+++ b/libs/angular-components/filter/filter-tree/src/filter-tree.component.html
@@ -13,7 +13,7 @@
     </li>
   </mat-tree-node>
   <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-    <li [class.tree-divider]="isRootNode(node)">
+    <li [class.tree-divider]="isRootNode(node) || hasChild">
       <div class="mat-tree-node">
         <mat-checkbox
           [checked]="descendantsAllSelected(node)"


### PR DESCRIPTION
Bug: when a parent node has the same label as a child node the divider is not displayed.

![Filter-Tree Bug](https://user-images.githubusercontent.com/56310827/68925717-5587cb00-078c-11ea-9159-848d352f2d40.PNG)
