### PR TITLE
feat(list): implement ordered list

### DIFF
--- a/themes/angular-theme/lib/list/_list-base.scss
+++ b/themes/angular-theme/lib/list/_list-base.scss
@@ -1,3 +1,5 @@
+@import '../core/style/spacing';
+
 // uxg-link-list
 $uxg-link-list-item-height: 35px;
 $uxg-link-list-icon-size: 18px;
@@ -5,6 +7,36 @@ $uxg-link-list-icon-size: 18px;
 // uxg-nav-list
 $uxg-nav-list-level-icon-size: 18px;
 $uxg-nav-list-level-height: 48px;
+
+ol.uxg-ol {
+  counter-reset: ordered-list-counter;
+  list-style: none;
+
+  li {
+    counter-increment: ordered-list-counter;
+
+    & + li {
+      margin-top: $uxg-spacing-3;
+    }
+
+    *:first-child,
+    .uxg-ol-title {
+      display: inline-block;
+      margin: $uxg-spacing-0;
+    }
+
+    &:before {
+      display: inline-block;
+      content: counter(ordered-list-counter);
+      border-radius: 50%;
+      text-align: center;
+      line-height: $uxg-spacing-4;
+      width: $uxg-spacing-4;
+      height: $uxg-spacing-4;
+      margin-right: $uxg-spacing-3;
+    }
+  }
+}
 
 .uxg-nav-list-level.mat-nav-list.mat-list-base {
   & > .mat-list-item {

--- a/themes/angular-theme/lib/list/_list-base.scss
+++ b/themes/angular-theme/lib/list/_list-base.scss
@@ -8,16 +8,24 @@ $uxg-link-list-icon-size: 18px;
 $uxg-nav-list-level-icon-size: 18px;
 $uxg-nav-list-level-height: 48px;
 
-ol.uxg-ol {
+.uxg-ol {
+  margin: $uxg-spacing-0;
+  padding: $uxg-spacing-0;
   counter-reset: ordered-list-counter;
   list-style: none;
-
-  li {
+  
+  & > li,
+  & > section {
+    display: list-item;
     counter-increment: ordered-list-counter;
+    margin: $uxg-spacing-0;
+    padding: $uxg-spacing-0;
 
-    & + li {
+    & + li,
+    & + section {
       margin-top: $uxg-spacing-3;
     }
+
 
     *:first-child,
     .uxg-ol-title {

--- a/themes/angular-theme/lib/list/_list-base.scss
+++ b/themes/angular-theme/lib/list/_list-base.scss
@@ -25,7 +25,7 @@ ol.uxg-ol {
       margin: $uxg-spacing-0;
     }
 
-    &:before {
+    &::before {
       display: inline-block;
       content: counter(ordered-list-counter);
       border-radius: 50%;

--- a/themes/angular-theme/lib/list/_list-base.scss
+++ b/themes/angular-theme/lib/list/_list-base.scss
@@ -13,7 +13,7 @@ $uxg-nav-list-level-height: 48px;
   padding: $uxg-spacing-0;
   counter-reset: ordered-list-counter;
   list-style: none;
-  
+
   & > li,
   & > section {
     display: list-item;
@@ -25,7 +25,6 @@ $uxg-nav-list-level-height: 48px;
     & + section {
       margin-top: $uxg-spacing-3;
     }
-
 
     *:first-child,
     .uxg-ol-title {

--- a/themes/angular-theme/lib/list/_list-theme.scss
+++ b/themes/angular-theme/lib/list/_list-theme.scss
@@ -3,7 +3,7 @@
   $foreground: map-get($theme, foreground);
 
   .uxg-ol {
-    li::before {
+    *::before {
       color: map-get($primary, default-contrast);
       background: mat-color($primary, default);
     }
@@ -61,7 +61,7 @@
   }
 
   .uxg-ol {
-    li::before {
+    *::before {
       @include mat-typography-level-to-styles($config, h6);
     }
 

--- a/themes/angular-theme/lib/list/_list-theme.scss
+++ b/themes/angular-theme/lib/list/_list-theme.scss
@@ -2,6 +2,13 @@
   $primary: map-get($theme, primary);
   $foreground: map-get($theme, foreground);
 
+  .uxg-ol {
+    li:before {
+      color: map-get($primary, default-contrast);
+      background: mat-color($primary, default);
+    }
+  }
+
   .mat-list-base.mat-nav-list {
     &.uxg-link-list {
       .mat-list-item {
@@ -50,6 +57,16 @@
   .mat-list-base.mat-nav-list.uxg-link-list {
     & .mat-list-item > * {
       @include mat-typography-level-to-styles($config, caption);
+    }
+  }
+
+  .uxg-ol {
+    li:before {
+      @include mat-typography-level-to-styles($config, h6);
+    }
+
+    .uxg-ol-title {
+      @include mat-typography-level-to-styles($config, subtitle-1);
     }
   }
 }

--- a/themes/angular-theme/lib/list/_list-theme.scss
+++ b/themes/angular-theme/lib/list/_list-theme.scss
@@ -3,7 +3,7 @@
   $foreground: map-get($theme, foreground);
 
   .uxg-ol {
-    li:before {
+    li::before {
       color: map-get($primary, default-contrast);
       background: mat-color($primary, default);
     }
@@ -61,7 +61,7 @@
   }
 
   .uxg-ol {
-    li:before {
+    li::before {
       @include mat-typography-level-to-styles($config, h6);
     }
 


### PR DESCRIPTION
Result:
![Screenshot 2019-11-20 at 17 48 23](https://user-images.githubusercontent.com/371041/69259142-0a235180-0bbe-11ea-988f-873674ee46bc.png)

Usage with `<ol>`:
```html
<ol class="uxg-ol">
  <li>
    <h5 class="uxg-ol-title">Item one</h5>
    <p class="uxg-body-1">Some text under the title of the ordered list.</p>
  </li>
  <li>anything without tag</li>
  <li>
    <p class="uxg-subtitle-3">test with p as subtitle-3</p>
    <p class="uxg-subtitle-3">test with p as subtitle-3</p>
  </li>
</ol>
```

Usage with `<section>`:
```html
<div class="uxg-ol">
  <section>
    <h5 class="uxg-ol-title">First step</h5>
    <p class="uxg-body-1">Some text under the title of the ordered list.</p>
  </section>
  <section>
    <h5 class="uxg-ol-title">Second step</h5>
    <p class="uxg-body-1">Some more content</p>
  </section>
</div>
```