### PR TITLE
fix(elevation): fix low contrast on cards border

### DIFF
--- a/themes/angular-theme/lib/core/style/_elevation.scss
+++ b/themes/angular-theme/lib/core/style/_elevation.scss
@@ -1,1 +1,1 @@
-$mat-elevation-opacity: 0.3;
+$mat-elevation-opacity: 0.8;

--- a/themes/angular-theme/lib/core/theming/_palette.scss
+++ b/themes/angular-theme/lib/core/theming/_palette.scss
@@ -189,7 +189,7 @@ $uxg-light-theme-foreground: (
   disabled:          $dark-disabled-text,
   disabled-button:   rgba(black, 0.25),
   disabled-text:     $dark-disabled-text,
-  elevation:         map_get($mat-grey, 900),
+  elevation:         black,
   hint-text:         $dark-disabled-text,
   secondary-text:    $dark-secondary-text,
   icon:              rgba(black, 0.5),


### PR DESCRIPTION
get closer to design specifications in Sketch file.
01dp card's elevation:
![Screenshot 2019-12-09 at 18 07 54](https://user-images.githubusercontent.com/371041/70456663-d9dd1d80-1aae-11ea-9023-791d3ec7f0b4.png)
