### PR TITLE
fix(icon-button): fixed icon-button behaviour when clicked in IE11

### DIFF
--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -22,7 +22,7 @@ $mat-icon-button-size-dense: 30px;
 
     .mat-icon {
       @include icon-size($icon-size);
-      
+
       padding-bottom: 2px;
     }
   }

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -22,7 +22,7 @@ $mat-icon-button-size-dense: 30px;
 
     .mat-icon {
       @include icon-size($icon-size);
-
+      
       padding-bottom: 2px;
     }
   }
@@ -36,13 +36,6 @@ button {
     display: inline-flex;
     align-content: center;
     justify-content: center;
-
-    .mat-button-wrapper {
-      display: flex;
-      margin: auto;
-      width: $button-icon-size-large;
-      height: $button-icon-size-large;
-    }
   }
 }
 
@@ -51,13 +44,6 @@ a[dense] {
   @include button-base($button-radius-dense, $button-icon-size-dense);
 
   &.mat-icon-button {
-    @include icon-size($mat-icon-button-size-dense);
-
-    .mat-button-wrapper {
-      width: $button-icon-size-base;
-      height: $button-icon-size-base;
-    }
-
     .mat-icon {
       @include icon-size($button-icon-size-base);
     }
@@ -69,14 +55,4 @@ a[large] {
   @include button-base($button-radius-large, $button-icon-size-large);
 
   padding: $uxg-spacing-0 $button-padding-large;
-}
-
-// graceful degradation targeting IE10+
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  a,
-  button {
-    &.mat-icon-button {
-      justify-content: flex-start
-    }
-  }
 }

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -44,8 +44,12 @@ a[dense] {
   @include button-base($button-radius-dense, $button-icon-size-dense);
 
   &.mat-icon-button {
+    @include icon-size($mat-icon-button-size-dense);
+
     .mat-icon {
       @include icon-size($button-icon-size-base);
+
+      height: 22px;
     }
   }
 }

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -76,7 +76,7 @@ a[large] {
   a,
   button {
     &.mat-icon-button {
-    justify-content: flex-start
+      justify-content: flex-start
+    }
   }
-}
 }

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -70,3 +70,13 @@ a[large] {
 
   padding: $uxg-spacing-0 $button-padding-large;
 }
+
+// graceful degradation targeting IE10+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  a,
+  button {
+    &.mat-icon-button {
+    justify-content: flex-start
+  }
+}
+}

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -22,7 +22,6 @@ $mat-icon-button-size-dense: 30px;
 
     .mat-icon {
       @include icon-size($icon-size);
-      
       padding-bottom: 2px;
     }
   }

--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -22,6 +22,7 @@ $mat-icon-button-size-dense: 30px;
 
     .mat-icon {
       @include icon-size($icon-size);
+      
       padding-bottom: 2px;
     }
   }

--- a/themes/angular-theme/lib/icon/_icon-base.scss
+++ b/themes/angular-theme/lib/icon/_icon-base.scss
@@ -6,10 +6,10 @@ $icon-size-base: $uxg-spacing-4;
 $icon-size-dense: 18px;
 
 @mixin icon-size($icon-size) {
-  width: $icon-size !important;
-  height: $icon-size !important;
-  font-size: $icon-size !important;
-  line-height: $icon-size !important;
+  width: $icon-size;
+  height: $icon-size;
+  font-size: $icon-size;
+  line-height: $icon-size;
 }
 
 .mat-icon[dense] {


### PR DESCRIPTION
mat-icon-button, when clicked in IE11, was displaying a crocked display. Now the icon is centered again.
![icon-button-issue-ie](https://user-images.githubusercontent.com/371041/73372120-00515500-42b7-11ea-98ae-17b5a9ccce3b.png)
