### PR TITLE
feat(app): enable dark theme in test app

### DIFF
--- a/apps/angular-test-app/src/app/app.component.html
+++ b/apps/angular-test-app/src/app/app.component.html
@@ -6,6 +6,7 @@
           <span class="uxg-h5 uxg-card-product-name">DS</span>
         </mat-card>
         <h6 class="uxg-h6">DESIGN SYSTEM</h6>
+        <mat-slide-toggle class="theme-toggle" (change)="toggleTheme()">Dark</mat-slide-toggle>
       </div>
       <mat-nav-list class="uxg-nav-list" (click)="sidenav.toggle()" dense>
         <h3 mat-subheader>Theme</h3>

--- a/apps/angular-test-app/src/app/app.component.scss
+++ b/apps/angular-test-app/src/app/app.component.scss
@@ -1,3 +1,5 @@
+@import 'angular-theme/lib/core/style/spacing';
+
 .main-container {
   height: 100%;
   width: 100%;
@@ -36,4 +38,8 @@ mat-sidenav-container {
   bottom: 0;
   left: 0;
   padding: 2rem;
+}
+
+.theme-toggle {
+  margin-left: $uxg-spacing-3;
 }

--- a/apps/angular-test-app/src/app/app.component.spec.ts
+++ b/apps/angular-test-app/src/app/app.component.spec.ts
@@ -4,6 +4,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -16,6 +17,7 @@ describe('AppComponent', () => {
       imports: [
         MatCardModule,
         MatSidenavModule,
+        MatSlideToggleModule,
         MatToolbarModule,
         MatIconModule,
         MatButtonModule,

--- a/apps/angular-test-app/src/app/app.component.ts
+++ b/apps/angular-test-app/src/app/app.component.ts
@@ -11,7 +11,12 @@ export class AppComponent {
   title = '';
   dark = false;
 
-  constructor(private router: Router, private route: ActivatedRoute, private _element: ElementRef<HTMLElement>, private _overlayContainer: OverlayContainer) {
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private _element: ElementRef<HTMLElement>,
+    private _overlayContainer: OverlayContainer
+  ) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         this.title = this.route.root.firstChild ? this.route.root.firstChild.snapshot.data['title'] : '';

--- a/apps/angular-test-app/src/app/app.component.ts
+++ b/apps/angular-test-app/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef } from '@angular/core';
+import { Component, Renderer2, Inject } from '@angular/core';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
 import { OverlayContainer } from '@angular/cdk/overlay';
 
 @Component({
@@ -14,7 +15,8 @@ export class AppComponent {
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    private _element: ElementRef<HTMLElement>,
+    @Inject(DOCUMENT) private document: Document,
+    private renderer: Renderer2,
     private _overlayContainer: OverlayContainer
   ) {
     this.router.events.subscribe(event => {
@@ -30,10 +32,10 @@ export class AppComponent {
     this.dark = !this.dark;
 
     if (this.dark) {
-      this._element.nativeElement.classList.add(darkThemeClass);
+      this.renderer.addClass(this.document.body, darkThemeClass);
       this._overlayContainer.getContainerElement().classList.add(darkThemeClass);
     } else {
-      this._element.nativeElement.classList.remove(darkThemeClass);
+      this.renderer.removeClass(this.document.body, darkThemeClass);
       this._overlayContainer.getContainerElement().classList.remove(darkThemeClass);
     }
   }

--- a/apps/angular-test-app/src/app/app.component.ts
+++ b/apps/angular-test-app/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { OverlayContainer } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'ffdc-root',
@@ -8,12 +9,27 @@ import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 })
 export class AppComponent {
   title = '';
+  dark = false;
 
-  constructor(private router: Router, private route: ActivatedRoute) {
+  constructor(private router: Router, private route: ActivatedRoute, private _element: ElementRef<HTMLElement>, private _overlayContainer: OverlayContainer) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         this.title = this.route.root.firstChild ? this.route.root.firstChild.snapshot.data['title'] : '';
       }
     });
+  }
+
+  toggleTheme() {
+    const darkThemeClass = 'uxg-dark-theme';
+
+    this.dark = !this.dark;
+
+    if (this.dark) {
+      this._element.nativeElement.classList.add(darkThemeClass);
+      this._overlayContainer.getContainerElement().classList.add(darkThemeClass);
+    } else {
+      this._element.nativeElement.classList.remove(darkThemeClass);
+      this._overlayContainer.getContainerElement().classList.remove(darkThemeClass);
+    }
   }
 }


### PR DESCRIPTION
Add a checkbox to switch to dark theme.
It reveals some components are not theme ready.

![Screenshot 2020-02-13 at 14 33 28](https://user-images.githubusercontent.com/371041/74440216-e3e41980-4e6d-11ea-9b69-f82b2b919882.png)
