### PR TITLE
fix(logo): force pointer cursor when logo used as a link

### DIFF
--- a/themes/angular-theme/lib/logo/_logo-base.scss
+++ b/themes/angular-theme/lib/logo/_logo-base.scss
@@ -7,6 +7,10 @@ $uxg-logo-height: 60px;
   height: $height;
 }
 
+a.uxg-logo {
+  cursor: pointer;
+}
+
 .uxg-logo {
   @include logo-size($uxg-logo-width, $uxg-logo-height);
 


### PR DESCRIPTION
Fix #171, when we use `<a>` tag without `href` parameter we still need the pointer cursor. It's very common in Angular when using `RouterLink` or `(click)` to trigger action or navigation.