### PR TITLE
chore(config): added release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [12.x]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+    - name: NX Setup
+      shell: bash
+      run: |
+        git fetch origin master
+        git checkout -qf FETCH_HEAD
+      
+      # Setup
+    - name: Install Dependencies
+      run: npm ci --loglevel=error
+    - name: Build DevKit
+      run: npm run build:devkit
+      
+      # Test
+    - name: Content list
+      uses: enricomarino/actions@v2
+    - name: Lint affected files
+      run: npm run affected:lint -- --base=origin/master --parallel
+    - name: Check formatting
+      run: npm run format:check -- --base=origin/master --parallel
+    - name: Run affected unit tests
+      run: npm run affected:test -- --base=origin/master --parallel
+      
+      # Build
+    - name: Build Test App
+      run: npm run build -- --prod
+    - name: Build Angular Theme
+      run: npm run build angular-theme -- --prod
+    - name: Build Angular Components
+      run: npm run build angular-components
+    - name: Upload Angular Theme Artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: 'uxg-angular-theme'
+        path: './dist/themes/angular-theme'
+    - name: Upload Angular Components Artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: 'uxg-angular-components'
+        path: './dist/libs/angular-components'
+      
+      # Publish
+    - name: Publish Components
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.FFDC_BOT_NPM_AUTH_TOKEN }}
+        package: ./dist/libs/angular-components/package.json
+    - name: Publish Theme
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.FFDC_BOT_NPM_AUTH_TOKEN }}
+        package: ./dist/themes/angular-theme/package.json


### PR DESCRIPTION
Moved the release from Azure DevOps to Githb Actions.
Steps on how to release:
1. commit to master `chore(release): prepare for VERSION release`
2. create release tag

And the workflow should start and do the release :)

Note:
Now that we are quite happy with the contents, we can stop doing pre-releases.