### PR TITLE
fix(config): import should be the same for css and sass

### DIFF
--- a/themes/angular-theme/package.json
+++ b/themes/angular-theme/package.json
@@ -4,7 +4,7 @@
   "description": "Angular Material implementation of the Finastra Design System",
   "license": "MIT",
   "sass": "_all-theme.scss",
-  "css": "_all-theme.css",
+  "css": "all-theme.css",
   "peerDependencies": {
     "@angular/material": "^9.0.0"
   }

--- a/tools/devkit/builders/theme/theme-builder.ts
+++ b/tools/devkit/builders/theme/theme-builder.ts
@@ -33,7 +33,7 @@ async function themeBuilder(options: Schema, context: BuilderContext): Promise<B
     }
 
     const from = join(dest, pkg.sass);
-    const to = join(dest, pkg.sass.replace('.scss', '.css'));
+    const to = join(dest, pkg.css || pkg.sass.replace('.scss', '.css'));
     logger.info(`Compiling "${from}" to "${to}"...`);
 
     const result = renderSync({


### PR DESCRIPTION
According to FDS documentation, import should look like this
```SCSS
@import '~@ffdc/uxg-angular-theme/all-theme';
```
Which is fine for an Angular SASS project but not compatible with a project running `ng new` choosing CSS for styling and trying to import `_all-theme.css`