### PR TITLE
fix(global-nav): Display current node in navbar

### DIFF
--- a/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
+++ b/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
@@ -14,7 +14,7 @@ export class GlobalNavDemoComponent {
 
   demoAppList: NavigationNode[] = [
     {
-      path: 'global-nav',
+      path: 'app1.com',
       title: 'app1',
       tooltip: 'app1',
       icon: 'dashboard'

--- a/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
+++ b/apps/angular-test-app/src/app/components/global-nav-demo/global-nav-demo.component.ts
@@ -14,7 +14,7 @@ export class GlobalNavDemoComponent {
 
   demoAppList: NavigationNode[] = [
     {
-      path: 'app1.com',
+      path: 'global-nav',
       title: 'app1',
       tooltip: 'app1',
       icon: 'dashboard'

--- a/libs/angular-components/cards/account-card/README.md
+++ b/libs/angular-components/cards/account-card/README.md
@@ -37,8 +37,9 @@ export class AppModule {}
 </ng-container>
 
 <ng-template #loading>
-  <uxg-account-card-skeleton *ngFor="let skeleton of 4 | nbToArray"> </uxg-account-card-skeleton>
+  <uxg-account-card-skeleton></uxg-account-card-skeleton>
+  <uxg-account-card-skeleton></uxg-account-card-skeleton>
+  <uxg-account-card-skeleton></uxg-account-card-skeleton>
+  <uxg-account-card-skeleton></uxg-account-card-skeleton>
 </ng-template>
 ```
-
-> Usage of `nbToArray` requires importing `NbToArrayModule` from `@ffdc/uxg-angular-components/core`

--- a/libs/angular-components/global-nav/src/_variables.scss
+++ b/libs/angular-components/global-nav/src/_variables.scss
@@ -1,0 +1,4 @@
+$z-index: (
+    NAVBAR: 15,
+    SIDENAV: 102
+);

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.html
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.html
@@ -9,7 +9,7 @@
   >
     <mat-icon>menu</mat-icon>
   </button>
-  
+
   <a
     href="javascript:void(0)"
     (click)="brandAction.emit($event)"
@@ -17,15 +17,15 @@
     class="uxg-logo"
     dense
   ></a>
-  
+
   <ul class="uxg-breadcrumb uxg-breadcrumb-responsive">
-		<button mat-icon-button color="accent" class="uxg-breadcrumb-back">
+    <button mat-icon-button color="accent" class="uxg-breadcrumb-back">
       <mat-icon>chevron_left</mat-icon>
     </button>
-    <li class="uxg-h6">{{appName}}</li>
-    <li *ngIf="currentNode">{{currentNode?.title}}</li>
+    <li class="uxg-h6">{{ appName }}</li>
+    <li *ngIf="currentNode">{{ currentNode?.title }}</li>
   </ul>
-  
+
   <span class="fill-remaining-space"></span>
 
   <ng-container *ngTemplateOutlet="navbarAction"></ng-container>

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.html
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.html
@@ -1,23 +1,32 @@
 <mat-toolbar class="uxg-toolbar uxg-toolbar-elevated">
-  <mat-toolbar-row>
-    <button
-      class="uxg-nav-header-button"
-      mat-icon-button
-      mat-primary
-      color="primary"
-      (click)="onMenuClick()"
-      aria-label="Menu"
-    >
-      <mat-icon>menu</mat-icon>
+  <button
+    class="uxg-nav-header-button"
+    mat-icon-button
+    mat-primary
+    color="primary"
+    (click)="onMenuClick()"
+    aria-label="Menu"
+  >
+    <mat-icon>menu</mat-icon>
+  </button>
+  
+  <a
+    href="javascript:void(0)"
+    (click)="brandAction.emit($event)"
+    aria-label="Go to Finastra website"
+    class="uxg-logo"
+    dense
+  ></a>
+  
+  <ul class="uxg-breadcrumb uxg-breadcrumb-responsive">
+		<button mat-icon-button color="accent" class="uxg-breadcrumb-back">
+      <mat-icon>chevron_left</mat-icon>
     </button>
-    <a
-      href="javascript:void(0)"
-      (click)="brandAction.emit($event)"
-      aria-label="Go to Finastra website"
-      class="uxg-logo"
-      dense
-    ></a>
-    <span class="fill-remaining-space"></span>
-    <ng-container *ngTemplateOutlet="navbarAction"></ng-container>
-  </mat-toolbar-row>
+    <li class="uxg-h6">{{appName}}</li>
+    <li *ngIf="currentNode">{{currentNode?.title}}</li>
+  </ul>
+  
+  <span class="fill-remaining-space"></span>
+
+  <ng-container *ngTemplateOutlet="navbarAction"></ng-container>
 </mat-toolbar>

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.scss
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.scss
@@ -1,5 +1,12 @@
+@import "../../variables";
+
 uxg-navbar {
   position: unset;
+}
+
+.uxg-toolbar {
+  z-index: map-get($z-index, NAVBAR);
+  position: relative;
 }
   
 .uxg-nav-list.mat-nav-list.mat-list-base > .mat-list-item:last-of-type, .uxg-nav-list-level.mat-nav-list.mat-list-base > .mat-list-item:last-of-type {

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
@@ -19,13 +19,9 @@ export class NavbarComponent implements OnInit, OnDestroy, OnChanges {
   @Output() brandAction = new EventEmitter<any>();
   @Output() nodeChosen = new EventEmitter<NavigationNode>();
 
-  ngOnInit() {
-    console.log(this.currentNode);
-  }
+  ngOnInit() {}
 
-  ngOnChanges() {
-    console.log('changes', arguments);
-  }
+  ngOnChanges() {}
 
   ngOnDestroy() {}
 

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
@@ -20,11 +20,11 @@ export class NavbarComponent implements OnInit, OnDestroy, OnChanges {
   @Output() nodeChosen = new EventEmitter<NavigationNode>();
 
   ngOnInit() {
-    console.log(this.currentNode)
+    console.log(this.currentNode);
   }
 
   ngOnChanges() {
-    console.log('changes', arguments)
+    console.log('changes', arguments);
   }
 
   ngOnDestroy() {}

--- a/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
+++ b/libs/angular-components/global-nav/src/components/navbar/navbar.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, OnDestroy, Output, EventEmitter, Input, TemplateRef } from '@angular/core';
-import { NavigationNode, CurrentNode } from '../../services/navigation.model';
+import { Component, OnInit, OnDestroy, Output, EventEmitter, Input, TemplateRef, OnChanges } from '@angular/core';
+import { NavigationNode } from '../../services/navigation.model';
 
 @Component({
   selector: 'uxg-navbar',
@@ -9,16 +9,24 @@ import { NavigationNode, CurrentNode } from '../../services/navigation.model';
     class: 'uxg-navbar'
   }
 })
-export class NavbarComponent implements OnInit, OnDestroy {
+export class NavbarComponent implements OnInit, OnDestroy, OnChanges {
   @Input() brandIcon: string | undefined;
-  @Input() currentNode: CurrentNode | undefined;
+  @Input() currentNode!: NavigationNode;
   @Input() navbarAction!: TemplateRef<any>;
+  @Input() appName!: string;
 
   @Output() menuClick = new EventEmitter<void>();
   @Output() brandAction = new EventEmitter<any>();
   @Output() nodeChosen = new EventEmitter<NavigationNode>();
 
-  ngOnInit() {}
+  ngOnInit() {
+    console.log(this.currentNode)
+  }
+
+  ngOnChanges() {
+    console.log('changes', arguments)
+  }
+
   ngOnDestroy() {}
 
   onMenuClick() {

--- a/libs/angular-components/global-nav/src/global-nav.component.html
+++ b/libs/angular-components/global-nav/src/global-nav.component.html
@@ -8,8 +8,10 @@
       (logout)="logout.emit()"
     ></uxg-sidenav>
   </mat-sidenav>
+
   <mat-sidenav-content>
     <uxg-navbar
+      [appName]="appName"
       [currentNode]="currentNode"
       [navbarAction]="navbarAction"
       (menuClick)="globalNavDrawer.toggle()"
@@ -17,8 +19,10 @@
       (brandAction)="brandAction.emit($event)"
     >
     </uxg-navbar>
+
     <div class="app-content">
       <ng-container *ngTemplateOutlet="appContent"></ng-container>
     </div>
+    
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/libs/angular-components/global-nav/src/global-nav.component.html
+++ b/libs/angular-components/global-nav/src/global-nav.component.html
@@ -23,6 +23,5 @@
     <div class="app-content">
       <ng-container *ngTemplateOutlet="appContent"></ng-container>
     </div>
-    
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/libs/angular-components/global-nav/src/global-nav.component.spec.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { GlobalNavComponent } from './global-nav.component';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -25,7 +26,8 @@ describe('GlobalNavModule', () => {
         MatButtonModule,
         MatCardModule,
         MatListModule,
-        NoopAnimationsModule
+        NoopAnimationsModule,
+        RouterTestingModule
       ],
       declarations: [GlobalNavComponent, NavbarComponent, SidenavComponent]
     }).compileComponents();

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, OnDestroy, Input, EventEmitter, Output, TemplateRef, ChangeDetectorRef } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Input,
+  EventEmitter,
+  Output,
+  TemplateRef
+} from '@angular/core';
 import { NavigationNode } from './services/navigation.model';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter, map } from 'rxjs/operators';
@@ -36,17 +44,13 @@ export class GlobalNavComponent implements OnInit, OnDestroy {
   ngOnDestroy() {}
 
   setCurrentNodeFromRouter() {
-    this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
-      .subscribe((currentRoute) => {
-        const route = (currentRoute as NavigationEnd).url
-        const currentNode = this.navigationNodes.find(
-          (node) => node.path && route.includes(node.path),
-        );
-        if (currentNode) {
-          this.currentNode = currentNode;
-          this.activeRoute = route;
-        }
-      });
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(currentRoute => {
+      const route = (currentRoute as NavigationEnd).url;
+      const currentNode = this.navigationNodes.find(node => node.path && route.includes(node.path));
+      if (currentNode) {
+        this.currentNode = currentNode;
+        this.activeRoute = route;
+      }
+    });
   }
 }

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -1,12 +1,4 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-  Input,
-  EventEmitter,
-  Output,
-  TemplateRef
-} from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, EventEmitter, Output, TemplateRef } from '@angular/core';
 import { NavigationNode } from './services/navigation.model';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter, map } from 'rxjs/operators';

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -27,8 +27,7 @@ export class GlobalNavComponent implements OnInit, OnDestroy {
 
   constructor(private router: Router) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   ngOnDestroy() {}
 }

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -14,8 +14,8 @@ import { filter, map } from 'rxjs/operators';
 export class GlobalNavComponent implements OnInit, OnDestroy {
   @Input() appName!: string;
   @Input() navigationNodes!: NavigationNode[];
-  @Input() activeRoute: string | false = false;
-  @Input() currentNode: NavigationNode | false = false;
+  @Input() activeRoute!: string;
+  @Input() currentNode!: NavigationNode;
   @Input() brandIcon: string | undefined;
   @Input() appContent!: TemplateRef<any>;
   @Input() navbarAction!: TemplateRef<any>;
@@ -28,21 +28,7 @@ export class GlobalNavComponent implements OnInit, OnDestroy {
   constructor(private router: Router) {}
 
   ngOnInit() {
-    if (!this.currentNode || !this.activeRoute) {
-      this.setCurrentNodeFromRouter();
-    }
   }
 
   ngOnDestroy() {}
-
-  setCurrentNodeFromRouter() {
-    this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(currentRoute => {
-      const route = (currentRoute as NavigationEnd).url;
-      const currentNode = this.navigationNodes.find(node => node.path && route.includes(node.path));
-      if (currentNode) {
-        this.currentNode = currentNode;
-        this.activeRoute = route;
-      }
-    });
-  }
 }

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, OnDestroy, Input, EventEmitter, Output, TemplateRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, EventEmitter, Output, TemplateRef, OnChanges, SimpleChanges } from '@angular/core';
 import { NavigationNode } from './services/navigation.model';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter, map } from 'rxjs/operators';
+import { ReplaySubject } from 'rxjs';
 
 @Component({
   selector: 'uxg-global-nav',
@@ -25,9 +26,30 @@ export class GlobalNavComponent implements OnInit, OnDestroy {
   @Output() nodeChosen = new EventEmitter<NavigationNode>();
   @Output() logout = new EventEmitter<void>();
 
-  constructor(private router: Router) {}
+  currentRoute = new ReplaySubject<string>();
 
-  ngOnInit() {}
+  constructor(private router: Router) {
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe((currentRoute) => {
+        const route = (currentRoute as NavigationEnd).url;
+        this.currentRoute.next(route);
+      });
+  }
+
+  ngOnInit() {
+    if (!this.currentNode) {
+      this.currentRoute.subscribe((currentRoute: string) => {
+        const currentNode = this.navigationNodes.find(
+          (node) => node.path === currentRoute.replace(/\//g, ''),
+        );
+        if (currentNode) {
+          this.currentNode = currentNode;
+          this.activeRoute = currentRoute;
+        }
+      });
+    }
+  }
 
   ngOnDestroy() {}
 }

--- a/libs/angular-components/global-nav/src/global-nav.component.ts
+++ b/libs/angular-components/global-nav/src/global-nav.component.ts
@@ -1,4 +1,14 @@
-import { Component, OnInit, OnDestroy, Input, EventEmitter, Output, TemplateRef, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Input,
+  EventEmitter,
+  Output,
+  TemplateRef,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 import { NavigationNode } from './services/navigation.model';
 import { Router, NavigationEnd } from '@angular/router';
 import { filter, map } from 'rxjs/operators';
@@ -29,20 +39,16 @@ export class GlobalNavComponent implements OnInit, OnDestroy {
   currentRoute = new ReplaySubject<string>();
 
   constructor(private router: Router) {
-    this.router.events
-      .pipe(filter((event) => event instanceof NavigationEnd))
-      .subscribe((currentRoute) => {
-        const route = (currentRoute as NavigationEnd).url;
-        this.currentRoute.next(route);
-      });
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(currentRoute => {
+      const route = (currentRoute as NavigationEnd).url;
+      this.currentRoute.next(route);
+    });
   }
 
   ngOnInit() {
     if (!this.currentNode) {
       this.currentRoute.subscribe((currentRoute: string) => {
-        const currentNode = this.navigationNodes.find(
-          (node) => node.path === currentRoute.replace(/\//g, ''),
-        );
+        const currentNode = this.navigationNodes.find(node => node.path === currentRoute.replace(/\//g, ''));
         if (currentNode) {
           this.currentNode = currentNode;
           this.activeRoute = currentRoute;

--- a/libs/angular-components/global-nav/src/services/navigation.model.ts
+++ b/libs/angular-components/global-nav/src/services/navigation.model.ts
@@ -17,22 +17,6 @@ export interface NavigationViews {
   [view: string]: NavigationNode[];
 }
 
-export interface CurrentNode {
-  path: string; // path of navigationNode.
-  currentPath?: string; // path of router
-  view: string;
-  nodes: NavigationNode[];
-}
-
-/**
- * A map of current nodes by view.
- * This is needed because some paths map to nodes in more than one view.
- * If a view does not contain a node that matches the current path then the value will be undefined.
- */
-export interface CurrentNodes {
-  [view: string]: CurrentNode;
-}
-
 export interface ParamMapBuilder {
   [key: string]: () => Promise<string>;
 }


### PR DESCRIPTION
If no `currentNode` is specified, it will try to infer it from the router.

Ideal setup :

`constants.ts`
```ts
export const routes = [
  {
    path: '',
    loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
    icon: 'home',
    title: 'Home',
    tooltip: 'Home',
  },
];
```

`app.routing.module.ts`
```ts
import { NgModule } from '@angular/core';
import { Routes, RouterModule } from '@angular/router';
import { AppComponent } from './app.component';
import { routes } from './constants';

@NgModule({
  imports: [
    RouterModule.forChild([
      {
        path: '',
        component: AppComponent,
        children: routes,
      },
    ]),
  ],
  exports: [RouterModule],
})
export class AppRoutingModule {}
```

`app.component.ts`
```ts
import { Component, OnInit } from '@angular/core';
import { routes } from './constants';
import { Router, NavigationEnd } from '@angular/router';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.scss'],
})
export class AppComponent {
  appName = 'Corporate Account Services';

  navigationNodes = routes;

  constructor( private router: Router) {}

  nodeChosen(node) {
    this.router.navigate([node.path]);
  }

  brandAction() {
    this.router.navigate(['home']);
  }
}
```