### PR TITLE
fix(doc): add reference to add-component schematic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,13 @@ When your issue is validated and you are assigned to it, you can start with thos
 > npm run build:devkit
 ```
 
+- In case you are adding a new feature as a component, use our schematic. Also add a demo of your component in the angular-test-app
+
+```sh
+> npm run add:component [your_component_name]
+> ng generate component [your_component_name]-demo -m app.module.ts --style=scss
+```
+
 - Write your code
 - Test your code, run linter
 


### PR DESCRIPTION
document the use of add-component schematic when creating a component for @ffdc/uxg-angular-components