### PR TITLE
fix(table): display flex only on div immediate child of <th>

### DIFF
--- a/themes/angular-theme/lib/table/_table-base.scss
+++ b/themes/angular-theme/lib/table/_table-base.scss
@@ -19,7 +19,7 @@ $uxg-table-row-height: 44px;
         padding-left: $uxg-table-cell-margin;
         padding-right: $uxg-table-cell-margin;
 
-        div {
+        & > div {
           display: flex;
         }
       }


### PR DESCRIPTION
fix #279