### PR TITLE
chore: Specify repository for packages to get insights about dependents

### DIFF
--- a/libs/angular-components/package.json
+++ b/libs/angular-components/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ffdc/uxg-angular-components",
   "version": "0.23.8",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fusionfabric/finastra-design-system.git",
+    "directory": "libs/angular-components"
+  },
   "peerDependencies": {
     "@angular/common": "^10.0.0",
     "@angular/core": "^10.0.0",

--- a/themes/angular-theme/package.json
+++ b/themes/angular-theme/package.json
@@ -5,6 +5,11 @@
   "license": "MIT",
   "sass": "_all-theme.scss",
   "css": "all-theme.css",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fusionfabric/finastra-design-system.git",
+    "directory": "themes/angular-theme"
+  },
   "peerDependencies": {
     "@angular/material": "^10.0.0"
   }


### PR DESCRIPTION
Hopefully fix :
![image](https://user-images.githubusercontent.com/569053/104750719-bfb34b80-5754-11eb-8864-5e9a01703d8a.png)

See for yourselves : https://github.com/fusionfabric/finastra-design-system/network/dependents
As compared to : https://github.com/angular/angular/network/dependents