### PR TITLE
fix(card): adapt product card text color to theme

### DIFF
--- a/themes/angular-theme/lib/card/_card-theme.scss
+++ b/themes/angular-theme/lib/card/_card-theme.scss
@@ -1,11 +1,12 @@
 @mixin uxg-card-theme($theme) {
   $primary: map-get($theme, primary);
   $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
   $card-wave: map-get($background, card-wave);
 
   .uxg-card-product.mat-card {
     background: bottom left / 100% 120% no-repeat url($card-wave), mat-color($uxg-gradient, horizontal);
-    color: $uxg-charcoal;
+    color: mat-color($foreground, text);
   }
 
   .uxg-card-solution.mat-card {


### PR DESCRIPTION
now text color adapts to the theme (white text on dark theme and dark text on light theme)

![image](https://user-images.githubusercontent.com/371041/105205527-a5f37900-5b45-11eb-921c-1bdf77215d81.png)

fix #309
