### PR TITLE
feat(icon-button): add hover state

### DIFF
--- a/themes/angular-theme/lib/button/_button-base.scss
+++ b/themes/angular-theme/lib/button/_button-base.scss
@@ -49,6 +49,10 @@ button {
       width: $button-icon-size-large;
       height: $button-icon-size-large;
     }
+
+    &:hover:not(.mat-button-disabled) .mat-button-focus-overlay {
+      opacity: 0.04;
+    }
   }
 }
 


### PR DESCRIPTION
Add subtle hover state on icon-button.
similar to what's already applied on default mat-button.

fix #290 


![icon-button-hover](https://user-images.githubusercontent.com/371041/107231762-f6614680-6a20-11eb-8bbe-050fca4e30f9.png)
