### PR TITLE
fix(global-search): make global search compatible with dark theme

### DIFF
--- a/libs/angular-components/global-search/src/_global-search.theme.scss
+++ b/libs/angular-components/global-search/src/_global-search.theme.scss
@@ -8,7 +8,9 @@
     background: mat-color($background, dialog, 0.95);
   }
 
-  uxg-global-search-overlay {
+  .uxg-global-search-overlay {
+    color: mat-color($foreground, text);
+
     .uxg-global-search-results-area {
       .uxg-global-search-result-group-header {
         .uxg-global-search-result-group-counter {
@@ -24,14 +26,13 @@
     .uxg-global-search-input-area {
       .uxg-global-search-input {
         .mat-form-field-label {
-          color: mat-color($foreground, text)
+          color: mat-color($foreground, text);
         }
       }
     }
 
     .uxg-global-search-close-overlay-button {
       opacity: 0.75;
-      color: mat-color($foreground, text);
     }
   }
 }

--- a/libs/angular-components/global-search/src/_global-search.theme.scss
+++ b/libs/angular-components/global-search/src/_global-search.theme.scss
@@ -31,6 +31,7 @@
 
     .uxg-global-search-close-overlay-button {
       opacity: 0.75;
+      color: mat-color($foreground, text);
     }
   }
 }


### PR DESCRIPTION
Global search close button was always dark.
Now it's following foreground text color (dark in light theme, light in dark theme)

![image](https://user-images.githubusercontent.com/371041/107369669-59ff7880-6ae2-11eb-9951-3923c31f040e.png)
