### PR TITLE
feat(wizard): sizing over container instead of viewport

### DIFF
--- a/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.html
+++ b/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.html
@@ -17,10 +17,7 @@
     <!--pages-->
     <uxg-wizard-page>
       <ng-template uxgWizardPageTitle>Step 1</ng-template>
-      <ng-template uxgWizardPageDescription>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus condimentum tincidunt urna, quis iaculis dui
-        consequat sed.
-      </ng-template>
+      <ng-template uxgWizardPageDescription> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </ng-template>
       <div>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus condimentum tincidunt urna, quis iaculis dui
@@ -67,28 +64,19 @@
 
     <uxg-wizard-page>
       <ng-template uxgWizardPageTitle>Step 2</ng-template>
-      <ng-template uxgWizardPageDescription>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus condimentum tincidunt urna, quis iaculis dui
-        consequat sed.
-      </ng-template>
+      <ng-template uxgWizardPageDescription> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </ng-template>
       <div>Step 2 content</div>
     </uxg-wizard-page>
 
     <uxg-wizard-page [uxgWizardPageDisabled]="true">
       <ng-template uxgWizardPageTitle>Step 3 (disabled)</ng-template>
-      <ng-template uxgWizardPageDescription>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus condimentum tincidunt urna, quis iaculis dui
-        consequat sed.
-      </ng-template>
+      <ng-template uxgWizardPageDescription> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </ng-template>
       <div>Step 3 content</div>
     </uxg-wizard-page>
 
     <uxg-wizard-page>
       <ng-template uxgWizardPageTitle>Step 4</ng-template>
-      <ng-template uxgWizardPageDescription>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus condimentum tincidunt urna, quis iaculis dui
-        consequat sed.
-      </ng-template>
+      <ng-template uxgWizardPageDescription> Lorem ipsum dolor sit amet, consectetur adipiscing elit. </ng-template>
       <div>Step 4 content</div>
     </uxg-wizard-page>
   </uxg-wizard>

--- a/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.scss
+++ b/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.scss
@@ -1,4 +1,7 @@
 .wizard-container {
-  width: 700px;
-  height: 600px;
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 0;
+  bottom: 0;
 }

--- a/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.scss
+++ b/apps/angular-test-app/src/app/components/wizard-demo/wizard-demo.component.scss
@@ -1,7 +1,4 @@
 .wizard-container {
-  position: absolute;
-  right: 0;
-  left: 0;
-  top: 0;
-  bottom: 0;
+  width: 700px;
+  height: 600px;
 }

--- a/libs/angular-components/wizard/src/wizard.component.html
+++ b/libs/angular-components/wizard/src/wizard.component.html
@@ -35,7 +35,7 @@
   </div>
 
   <div
-    class="uxg-wizard-container"
+    class="uxg-wizard-container mat-elevation-z4"
     fxLayout="column"
     fxFlex.xs="100"
     [ngClass.xs]="'xs'"

--- a/libs/angular-components/wizard/src/wizard.component.scss
+++ b/libs/angular-components/wizard/src/wizard.component.scss
@@ -18,27 +18,25 @@ $dot-size-xs: 8px;
 $timeline-progress-width: 4px;
 $timeline-progress-left-margin: 2px;
 
-$timeline-top: 15vh;
-$timeline-right: 2vw;
-$timeline-bottom: 15vh;
-$timeline-width: calc(22vw + #{$uxg-spacing-1});
-$timeline-top-xs: 4vh;
+$timeline-top: 15%;
+$timeline-right: 2%;
+$timeline-bottom: 15%;
+$timeline-width: calc(22% + #{$uxg-spacing-1});
+$timeline-top-xs: 4%;
 
-$wizard-container-top: 8vh;
-$wizard-container-bottom: 5vh;
-$wizard-container-left: 5vw;
-$wizard-container-right: 22vw;
+$wizard-container-top: 8%;
+$wizard-container-bottom: 5%;
+$wizard-container-left: 5%;
+$wizard-container-right: 22%;
 
-$wizard-page-height: 12vh;
+$wizard-page-height: 12%;
 $wizard-page-bottom: 0;
-$wizard-page-top: 12vh;
+$wizard-page-top: 12%;
 $wizard-page-right: 2rem;
 $wizard-page-left: 0;
 $wizard-page-top-xs: 0;
 
-$wizard-title-top: 3vh;
-$wizard-title-width: 73vw;
-$wizard-title-left: 5vw;
+$wizard-title-top: 3%;
 
 .uxg-wizard {
   position: relative;
@@ -79,8 +77,8 @@ $wizard-title-left: 5vw;
     display: flex;
     justify-content: center;
     top: $wizard-title-top;
-    width: $wizard-title-width;
-    left: $wizard-title-left;
+    left: $wizard-container-left;
+    right: $wizard-container-right;
   }
 
   .uxg-wizard-footer {

--- a/libs/angular-components/wizard/src/wizard.component.scss
+++ b/libs/angular-components/wizard/src/wizard.component.scss
@@ -1,4 +1,3 @@
-@import '~@angular/material/theming';
 @import 'angular-theme/lib/core/style/spacing';
 
 $buttons-wrapper-size: 44px;
@@ -42,7 +41,6 @@ $wizard-title-top: 3%;
   position: relative;
 
   .uxg-wizard-container {
-    @include mat-elevation(4);
     position: absolute;
     border-radius: $wizard-border-radius;
     top: $wizard-container-top;


### PR DESCRIPTION
⚠️ **To review carefully, making sure it won't affect apps already using it.**

Use % for sizing and positioning over vw and vh units.
Allow to use the wizard in a smaller container instead of full screen all the time.