### PR TITLE
fix(wizard): remove not necessary import to prevent css var bug

### DIFF
--- a/apps/angular-test-app/src/styles.scss
+++ b/apps/angular-test-app/src/styles.scss
@@ -27,6 +27,7 @@ $uxg-typography: uxg-typography-config();
 @include uxg-global-search-typography($uxg-typography);
 @include uxg-chart-typography($uxg-typography);
 @include uxg-changelog-typography($uxg-typography);
+@include uxg-wizard-typography($uxg-typography);
 
 @mixin app-theme($theme) {
   @include uxg-material-theme($theme);

--- a/libs/angular-components/wizard/src/_wizard.theme.scss
+++ b/libs/angular-components/wizard/src/_wizard.theme.scss
@@ -1,5 +1,3 @@
-@import 'angular-theme/lib/core/typography/typography';
-
 @mixin uxg-wizard-theme($theme) {
   $accent: map-get($theme, accent);
   $primary: map-get($theme, primary);
@@ -152,5 +150,3 @@
     }
   }
 }
-
-@include uxg-wizard-typography(uxg-typography-config());


### PR DESCRIPTION
loading typography inside wizard theme causes a reload of @angular/material/theming which then load the mat-color() mixin again which override our own override that helps handling CSS vars.