### PR TITLE
feat(theme): simplify theme inclusion

### DIFF
--- a/themes/angular-theme/_all-theme.scss
+++ b/themes/angular-theme/_all-theme.scss
@@ -6,6 +6,6 @@
 
 @include uxg-material-theme($uxg-light-theme);
 
-.uxg-dark-theme {
+@media (prefers-color-scheme: dark) {
   @include uxg-material-theme($uxg-dark-theme);
 }

--- a/themes/angular-theme/_dark.scss
+++ b/themes/angular-theme/_dark.scss
@@ -4,6 +4,4 @@
 
 @include uxg-core();
 
-.uxg-dark-theme {
-  @include uxg-material-theme($uxg-dark-theme);
-}
+@include uxg-material-theme($uxg-dark-theme);

--- a/themes/angular-theme/lib/core/theming/_all-theme.scss
+++ b/themes/angular-theme/lib/core/theming/_all-theme.scss
@@ -17,12 +17,23 @@
 @import '../../table/table-theme';
 @import '../../toolbar/toolbar-theme';
 @import 'color-utility';
+@import "light-variables";
+@import "dark-variables";
 
 @mixin uxg-core-theme($theme) {
   $foreground: map-get($theme, foreground);
   $background: map-get($theme, background);
+  $is-dark: map-get($theme, is-dark);
 
-  body {
+  #{if(&, '&', 'body')} {
+    @if $is-dark {
+      @include dark-vars();
+    }
+
+    @else {
+      @include light-vars();
+    }
+
     color: mat-color($foreground, text);
 
     *::selection {

--- a/themes/angular-theme/lib/core/theming/_palette.scss
+++ b/themes/angular-theme/lib/core/theming/_palette.scss
@@ -1,6 +1,4 @@
 @import "~@angular/material/theming";
-@import "light-variables";
-@import "dark-variables";
 
 @function mat-color($palette, $hue: default, $opacity: null) {
   // If hueKey is a number between zero and one, then it actually contains an
@@ -26,16 +24,6 @@
 }
 
 $uxg-charcoal: #414141;
-
-// Light theme CSS variables
-:root {
-  @include light-vars();
-}
-
-// Dark theme CSS variables
-.uxg-dark-theme {
-  @include dark-vars();
-}
 
 $uxg-violet: (
   50: #f7f6fd,
@@ -220,7 +208,7 @@ $uxg-dark-theme-background: (
   raised-button: #242424,
   focused-button: $light-focused,
   selected-button: map_get($mat-grey, 900),
-  selected-text: map_get($uxg-violet, 900),
+  selected-text: mat_color($uxg-violet, 500, 0.5),
   selected-disabled-button: #242424,
   disabled-button-toggle: black,
   unselected-chip: map_get($mat-grey, 700),

--- a/themes/angular-theme/lib/core/theming/_palette.scss
+++ b/themes/angular-theme/lib/core/theming/_palette.scss
@@ -208,7 +208,7 @@ $uxg-dark-theme-background: (
   raised-button: #242424,
   focused-button: $light-focused,
   selected-button: map_get($mat-grey, 900),
-  selected-text: mat_color($uxg-violet, 500, 0.5),
+  selected-text: map_get($uxg-violet, 900),
   selected-disabled-button: #242424,
   disabled-button-toggle: black,
   unselected-chip: map_get($mat-grey, 700),


### PR DESCRIPTION
Simplify the way you include the theme

You don't necessarily need to use `.uxg-dark-theme` anymore.
If you load only dark theme you can do:
```SCSS
@include uxg-material-theme($uxg-dark-theme);
```
If you load dark theme by default and switch with a custom class:
```SCSS
@include uxg-material-theme($uxg-dark-theme);

.any-class-you-want {
   @include uxg-material-theme($uxg-light-theme);
}
```
if you want to use user prefered color scheme then:
```SCSS
@include uxg-material-theme($uxg-light-theme);

@media (prefers-color-scheme: dark) {
   @include uxg-material-theme($uxg-dark-theme);
}
```